### PR TITLE
Remove socket.io dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   { "filed":">= 0.0.6",
     "routes":"*"
   }
-, "optionalDependencies": { "socket.io":"*" }
 , "devDependencies": { "request": "2.9.x" }
 , "scripts": { "test": "node tests/run.js" }
 }


### PR DESCRIPTION
It'll still work with socket.io if it's available, but there's
no need to force it to be installed since it will often not be
used, and takes a while to build.
