### PR TITLE
Plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ var util = require('util')
   , handlebars = require('./handlebars')
   , rfc822 = require('./rfc822')
   , io = null
+  , Cookies = require('cookies')
+  , Keygrip = require('keygrip')
   ;
 
 try {
@@ -301,6 +303,10 @@ function Application (options) {
     self.logger = self.options.logger
   }
 
+  if (options.keys) {
+    self.keygrip = new Keygrip(options.keys)
+  }
+
   self._plugins = {}
 
   self.router = new routes.Router()
@@ -466,6 +472,8 @@ Application.prototype._decorate = function (req, resp) {
   for (i in self.addHeaders) {
     resp.setHeader(i, self.addHeaders[i])
   }
+
+  req.cookies = resp.cookies = new Cookies(req, resp, self.keygrip)
 
   req.accept = function () {
     if (!req.headers.accept) return '*/*'

--- a/index.js
+++ b/index.js
@@ -381,6 +381,13 @@ Application.prototype._onRequest = function (req, resp) {
   })
 }
 
+Application.prototype.plugin = function (name, fn) {
+  if (this._plugins[name]) {
+    throw new Error('Plugin '+name+' already added')
+  }
+  this._plugins[name] = fn
+}
+
 Application.prototype._plug = function (req, resp, cb) {
   var plugins = Object.keys(this._plugins)
   var len = plugins.length

--- a/index.js
+++ b/index.js
@@ -271,8 +271,8 @@ function Application (options) {
 
   self.router = new routes.Router()
   self.on('newroute', function (route) {
-    self.router.addRoute(route.path, function (req, resp, authHandler) {
-      route.handler(req, resp, authHandler)
+    self.router.addRoute(route.path, function (req, resp) {
+      req.route = route
     })
   })
 
@@ -347,7 +347,9 @@ Application.prototype._onRequest = function (req, resp) {
 
   self.emit('request', req, resp)
 
-  req.match.fn.call(req.match, req, resp, self.authHandler)
+  // attach the route
+  req.match.fn(req, resp)
+  req.route.handler(req, resp)
 
   if (req.listeners('body').length) {
     var buffer = ''

--- a/index.js
+++ b/index.js
@@ -778,6 +778,13 @@ util.inherits(ServiceError, Error)
 ServiceError.prototype.name = 'ServiceError'
 module.exports.ServiceError = ServiceError
 
+
+
+
+
+// XXX Used by tako.router(), but other instances of
+// 'Router' are from routes.Router.  Can we get rid of
+// this somehow?
 function Router (hosts, options) {
   var self = this
   self.hosts = hosts || {}

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ BufferResponse.prototype.request = function (req, resp) {
     resp.statusCode = 405
     return (resp._end ? resp._end : resp.end).call(resp)
   }
-  if (this.cache && 
+  if (this.cache &&
       req.headers['if-none-match'] === this.etag ||
       req.headers['if-modified-since'] === this.timestamp
       ) {
@@ -128,7 +128,7 @@ function Page (templatename) {
         }
       })
     }
-    
+
     if (templatename) {
       self.template(templatename)
     }
@@ -188,7 +188,7 @@ function Templates (app) {
 util.inherits(Templates, events.EventEmitter)
 Templates.prototype.get = function (name, cb) {
   var self = this
-  
+
   if (name.indexOf(' ') !== -1 || name[0] === '<') {
     process.nextTick(function () {
       if (!self.tempcache[name]) {
@@ -198,7 +198,7 @@ Templates.prototype.get = function (name, cb) {
     })
     return
   }
-  
+
   function finish () {
     if (name in self.names) {
       cb(null, self.files[self.names[name]])
@@ -227,7 +227,7 @@ Templates.prototype.directory = function (dir) {
     self.loaded = true
     if (self.loading === 0) self.emit('loaded')
   })
-} 
+}
 
 function loadfiles (f, cb) {
   var filesmap = {}
@@ -265,19 +265,19 @@ function Application (options) {
   self.addHeaders = {}
   if (self.options.logger) {
     self.logger = self.options.logger
-  } 
-  
+  }
+
   self.onRequest = function (req, resp) {
     if (self.logger.info) self.logger.info('Request', req.url, req.headers)
     // Opt out entirely if this is a socketio request
     if (self.socketio && req.url.slice(0, '/socket.io/'.length) === '/socket.io/') {
       return self._ioEmitter.emit('request', req, resp)
     }
-    
+
     for (i in self.addHeaders) {
       resp.setHeader(i, self.addHeaders[i])
     }
-    
+
     req.accept = function () {
       if (!req.headers.accept) return '*/*'
       var cc = null
@@ -296,7 +296,7 @@ function Application (options) {
       self.logger.log('error %statusCode "%message "', err)
       resp.end(err.message || err) // this should be better
     }
-    
+
     resp.notfound = function (log) {
       if (log) self.logger.log(log)
       self.notfound(req, resp)
@@ -308,7 +308,7 @@ function Application (options) {
     for (i in parsed) {
       req[i] = parsed[i]
     }
-    
+
     if (req.query) req.qs = qs.parse(req.query)
 
     req.route = self.router.match(req.pathname)
@@ -366,12 +366,12 @@ function Application (options) {
       route.handler(req, resp, authHandler)
     })
   })
-  
+
   self.templates = new Templates(self)
-  
+
   // Default to having json enabled
   self.on('request', JSONRequestHandler)
-  
+
   // setup servers
   self.http = options.http || {}
   self.https = options.https || {}
@@ -383,39 +383,39 @@ function Application (options) {
   } else if (options.socketio) {
     throw new Error('socket.io is not available');
   }
-  
+
   self.httpServer = http.createServer()
   self.httpsServer = https.createServer(self.https)
-  
+
   self.httpServer.on('request', self.onRequest)
   self.httpsServer.on('request', self.onRequest)
-  
+
   var _listenProxied = false
   var listenProxy = function () {
     if (!_listenProxied && self._ioEmitter) self._ioEmitter.emit('listening')
     _listenProxied = true
   }
-  
+
   self.httpServer.on('listening', listenProxy)
   self.httpsServer.on('listening', listenProxy)
-  
+
   if (io && self.socketio) {
     // setup socket.io
     self._ioEmitter = new events.EventEmitter()
-    
+
     self.httpServer.on('upgrade', function (request, socket, head) {
       self._ioEmitter.emit('upgrade', request, socket, head)
     })
     self.httpsServer.on('upgrade', function (request, socket, head) {
       self._ioEmitter.emit('upgrade', request, socket, head)
     })
-    
+
     self.socketioManager = new io.Manager(self._ioEmitter, self.socketio)
     self.sockets = self.socketioManager.sockets
   }
-  
+
   if (!self.logger) {
-    self.logger = 
+    self.logger =
       { log: console.log
       , error: console.error
       , info: function () {}
@@ -495,11 +495,11 @@ Application.prototype.notfound = function (req, resp) {
     this._notfound = req
     return
   }
-  
+
   if (resp._header) return // This response already started
-  
+
   if (this._notfound) return this._notfound.request(req, resp)
-  
+
   var cc = req.accept('text/html', 'application/json', 'text/plain', '*/*') || 'text/plain'
   if (cc === '*/*') cc = 'text/plain'
   resp.statusCode = 404
@@ -513,16 +513,19 @@ Application.prototype.notfound = function (req, resp) {
   }
   resp.end(body)
 }
+
 Application.prototype.auth = function (handler) {
   if (!handler) return this.authHandler
   this.authHandler = handler
 }
+
 Application.prototype.page = function () {
   var page = new Page()
     , self = this
     ;
   page.application = self
-  page.template = function (name) {    
+
+  page.template = function (name) {
     var p = page.promise("template")
     self.templates.get(name, function (e, template) {
       if (e) return p(e)
@@ -626,7 +629,7 @@ function Route (path, application) {
       resp.end('Method not Allowed.')
       return
     }
-    
+
     self.emit('before', req, resp)
     if (self.authHandler) {
       authHandler = self.authHandler
@@ -686,13 +689,13 @@ function Route (path, application) {
         }
         run()
       }
-
     } else {
       returnEarly(req, resp, keys, authHandler)
     }
   }
   application.emit('newroute', self)
 }
+
 util.inherits(Route, events.EventEmitter)
 Route.prototype.json = function (cb) {
   if (Buffer.isBuffer(cb)) cb = new BufferResponse(cb, 'application/json')
@@ -704,6 +707,7 @@ Route.prototype.json = function (cb) {
   this.byContentType['application/json'] = cb
   return this
 }
+
 Route.prototype.html = function (cb) {
   if (Buffer.isBuffer(cb)) cb = new BufferResponse(cb, 'text/html')
   else if (typeof cb === 'string') {
@@ -713,6 +717,7 @@ Route.prototype.html = function (cb) {
   this.byContentType['text/html'] = cb
   return this
 }
+
 Route.prototype.text = function (cb) {
   if (Buffer.isBuffer(cb)) cb = new BufferResponse(cb, 'text/plain')
   else if (typeof cb === 'string') {
@@ -723,6 +728,7 @@ Route.prototype.text = function (cb) {
   return this
 }
 
+
 Route.prototype.file = function (filepath) {
   this.on('request', function (req, resp) {
     var f = filed(filepath)
@@ -731,6 +737,7 @@ Route.prototype.file = function (filepath) {
   })
   return this
 }
+
 Route.prototype.files = function (filepath) {
   this.on('request', function (req, resp) {
     req.route.splats.unshift(filepath)
@@ -745,19 +752,23 @@ Route.prototype.files = function (filepath) {
   })
   return this
 }
+
 Route.prototype.auth = function (handler) {
   if (!handler) return this.authHandler
   this.authHandler = handler
   return this
 }
+
 Route.prototype.must = function () {
   this._must = Array.prototype.slice.call(arguments)
   return this
 }
+
 Route.prototype.methods = function () {
   this._methods = Array.prototype.slice.call(arguments)
   return this
 }
+
 
 function ServiceError(msg) {
   Error.apply(this, arguments)
@@ -773,7 +784,7 @@ function Router (hosts, options) {
   var self = this
   self.hosts = hosts || {}
   self.options = options || {}
-  
+
   function makeHandler (type) {
     var handler = function (req, resp) {
       var host = req.headers.host
@@ -790,22 +801,25 @@ function Router (hosts, options) {
     }
     return handler
   }
-  
+
   self.httpServer = http.createServer()
   self.httpsServer = https.createServer(self.options.ssl || {})
-  
+
   self.httpServer.on('request', makeHandler('request'))
   self.httpsServer.on('request', makeHandler('request'))
-  
+
   self.httpServer.on('upgrade', makeHandler('upgrade'))
   self.httpsServer.on('upgrade', makeHandler('upgrade'))
 }
+
 Router.prototype.host = function (host, app) {
   this.hosts[host] = app
 }
+
 Router.prototype.default = function (app) {
   this._default = app
 }
+
 Router.prototype.close = function (cb) {
   var counter = 1
     , self = this
@@ -824,13 +838,13 @@ Router.prototype.close = function (cb) {
     self.httpsServer.once('close', end)
     self.httpsServer.close()
   }
-  
+
   for (i in self.hosts) {
     counter++
     process.nextTick(function () {
       self.hosts[i].close(end)
     })
-    
+
   }
   end()
 }

--- a/index.js
+++ b/index.js
@@ -395,7 +395,7 @@ Application.prototype._decorate = function (req, resp) {
   // Get all the parsed url properties on the request
   // This is the same style express uses and it's quite nice
   var parsed = url.parse(req.url)
-  for (i in parsed) {
+  for (i in parsed) if (i !== 'auth') {
     req[i] = parsed[i]
   }
 
@@ -410,21 +410,6 @@ Application.prototype._decorate = function (req, resp) {
   if (!req.route) return
 
   req.params = req.route.params
-
-  var onWrites = []
-  resp._write = resp.write
-  resp.write = function () {
-    if (resp.statusCode === 404 && self._notfound) {
-      return self._notfound.request(req, resp)
-    }
-    if (onWrites.length === 0) return resp._write.apply(resp, arguments)
-    var args = arguments
-    onWrites.forEach(function (onWrite) {
-      var c = onWrite.apply(resp, args)
-      if (c !== undefined) args[0] = c
-    })
-    return resp._write.apply(resp, args)
-  }
 
   // Fix for node's premature header check in end()
   resp._end = resp.end

--- a/index.js
+++ b/index.js
@@ -771,12 +771,10 @@ Route.prototype.methods = function () {
 
 
 function ServiceError(msg) {
-  Error.apply(this, arguments)
-  this.message = msg 
-  this.stack = (new Error()).stack;
+  this.message = msg
+  Error.captureStackTrace(this, ServiceError);
 }
-ServiceError.prototype = new Error()
-ServiceError.prototype.constructor = ServiceError
+util.inherits(ServiceError, Error)
 ServiceError.prototype.name = 'ServiceError'
 module.exports.ServiceError = ServiceError
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
 , "main" : "./index.html"
 , "dependencies": 
   { "filed":">= 0.0.6",
-    "routes":"*"
+    "routes":"*",
+    "cookies":"0.2",
+    "keygrip":"0.2"
   }
 , "devDependencies": { "request": "2.9.x" }
 , "scripts": { "test": "node tests/run.js" }

--- a/tests/test-basic.js
+++ b/tests/test-basic.js
@@ -13,7 +13,7 @@ t
     .html(function (req, resp) {
       resp.end('<html><body>Hello World</body></html>')
     })
-    .on('request', function (req, resp) {
+    .default(function (req, resp) {
       resp.statusCode = 200
       resp.setHeader('content-type', 'text/plain')
       resp.end('hello')
@@ -58,6 +58,7 @@ t.httpServer.listen(8000, function () {
   request({url:url,headers:{'accept':'application/json'}}, function (e, resp, body) {
     if (e) throw e
     if (resp.statusCode !== 200) throw new Error('status code is not 200. '+resp.statusCode)
+    console.error(resp.headers, body)
     assert.equal(resp.headers['content-type'], 'application/json')
     assert.equal(body, JSON.stringify({text:'hello world'}))
     console.log('Passed json /')
@@ -105,6 +106,7 @@ t.httpServer.listen(8000, function () {
 
   counter++
   request({url:url+'static',headers:{'accept':'text/html'}}, function (e, resp, body) {
+    console.log('... html /static', resp.headers, body)
     if (e) throw e
     if (resp.statusCode !== 200) throw new Error('status code is not 200. '+resp.statusCode)
     assert.equal(resp.headers['content-type'], 'text/html')

--- a/tests/test-cookies.js
+++ b/tests/test-cookies.js
@@ -1,0 +1,116 @@
+var tako = require('../index')
+  , request = require('request')
+  , assert = require('assert')
+  , fs = require('fs')
+  , j = request.jar()
+  ;
+
+var t = tako({ keys: ["just testing"] })
+
+t
+  .route('/set')
+    .json(function (req, resp) {
+      resp.cookies.set("hello", "World", { signed: true })
+      resp.end({text:'Hello, World'})
+    })
+    .html(function (req, resp) {
+      resp.cookies.set("hello", "World", { signed: true })
+      resp.end('<html><body>Hello, World</body></html>')
+    })
+
+t
+  .route('/get')
+    .json(function (req, resp) {
+      assert(req.cookies.get("hello") === "World")
+      resp.end({text: "ok"})
+    })
+    .html(function (req, resp) {
+      assert(req.cookies.get("hello") === "World")
+      resp.end('<html><body>ok</body></html>')
+    })
+
+t
+  .route('/get-signed')
+    .json(function (req, resp) {
+      assert(req.cookies.get("hello", {signed: true}) === "World")
+      resp.end({text: "ok"})
+    })
+    .html(function (req, resp) {
+      assert(req.cookies.get("hello", {signed: true}) === "World")
+      resp.end('<html><body>ok</body></html>')
+    })
+
+
+var url = 'http://localhost:8000'
+var set = url + '/set'
+var get = url + '/get'
+var getSigned = url + '/get-signed'
+
+counter = 0
+
+function end (next) {
+  counter--
+  if (counter === 0) next ? next() : t.close()
+}
+
+t.httpServer.listen(8000, function () {
+  counter++
+  request({url:set,jar:j,headers:{'accept':'application/json'}}, function (e, resp, body) {
+    if (e) throw e
+    if (resp.statusCode !== 200) throw new Error('status code is not 200. '+resp.statusCode)
+    assert.equal(resp.headers['content-type'], 'application/json')
+    assert.equal(body, JSON.stringify({text:'Hello, World'}))
+    console.log('Passed json /set')
+    end(testGet)
+  })
+
+  counter++
+  request({url:set,jar:j,headers:{'accept':'text/html'}}, function (e, resp, body) {
+    if (e) throw e
+    if (resp.statusCode !== 200) throw new Error('status code is not 200. '+resp.statusCode)
+    assert.equal(resp.headers['content-type'], 'text/html')
+    assert.equal(body, '<html><body>Hello, World</body></html>')
+    console.log('Passed html /set')
+    end(testGet)
+  })
+
+  function testGet () {
+    counter++
+    request({url:get,jar:j,headers:{'accept':'application/json'}}, function (e, resp, body) {
+      if (e) throw e
+      if (resp.statusCode !== 200) throw new Error('status code is not 200. '+resp.statusCode)
+      assert.equal(resp.headers['content-type'], 'application/json')
+      assert.equal(body, JSON.stringify({text:'ok'}))
+      console.log('Passed json /get')
+      end()
+    })
+
+    counter++
+    request({url:get,jar:j,headers:{'accept':'text/html'}}, function (e, resp, body) {
+      if (e) throw e
+      if (resp.statusCode !== 200) throw new Error('status code is not 200. '+resp.statusCode)
+      assert.equal(resp.headers['content-type'], 'text/html')
+      console.log('Passed html /get')
+      end()
+    })
+
+    counter++
+    request({url:getSigned,jar:j,headers:{'accept':'application/json'}}, function (e, resp, body) {
+      if (e) throw e
+      if (resp.statusCode !== 200) throw new Error('status code is not 200. '+resp.statusCode)
+      assert.equal(resp.headers['content-type'], 'application/json')
+      assert.equal(body, JSON.stringify({text:'ok'}))
+      console.log('Passed json /get-signed')
+      end()
+    })
+
+    counter++
+    request({url:getSigned,jar:j,headers:{'accept':'text/html'}}, function (e, resp, body) {
+      if (e) throw e
+      if (resp.statusCode !== 200) throw new Error('status code is not 200. '+resp.statusCode)
+      assert.equal(resp.headers['content-type'], 'text/html')
+      console.log('Passed html /get-signed')
+      end()
+    })
+  }
+})

--- a/tests/test-hostrouter.js
+++ b/tests/test-hostrouter.js
@@ -7,7 +7,7 @@ var tako = require('../index')
   , router = tako.router()
   , counter = 0
   ;
-  
+
 app1.route('/name').text('app1')
 app2.route('/name').text('app2')
 app3.route('/name').text('app3')
@@ -34,7 +34,7 @@ router.httpServer.listen(8080, function () {
     assert.equal(resp.body, 'app1')
     end()
   })
-  
+
   counter++
   request('http://localhost:8080/name', {headers:{host:'app2.localhost'}}, function (e, resp) {
     assert.ok(!e)
@@ -42,7 +42,7 @@ router.httpServer.listen(8080, function () {
     assert.equal(resp.body, 'app2')
     end()
   })
-  
+
   counter++
   request('http://localhost:8080/name', {headers:{host:'unknown.localhost'}}, function (e, resp) {
     assert.ok(!e)

--- a/tests/test-methods.js
+++ b/tests/test-methods.js
@@ -1,0 +1,77 @@
+var assert = require('assert')
+  , request = require('request')
+  , common = require('./common')
+  , tako = require('../')
+  , app = tako()
+
+var URL = common.URL
+  , HTML = '<h1>Hello world</h1>'
+  , getCalled = false
+  , putCalled = false
+  , postCalled = false
+
+app.route('/')
+  .get(function (req, res) {
+    console.error('GET handler called')
+    assert(!getCalled)
+    getCalled = true
+    res.end('ok')
+  })
+  .put(function (req, res) {
+    console.error('PUT handler called')
+    assert(!putCalled)
+    putCalled = true
+    res.end('ok')
+  })
+  .post(function (req, res) {
+    console.error('POST handler called')
+    assert(!postCalled)
+    postCalled = true
+    res.end('ok')
+  })
+  .default(function (req, res) {
+    console.error('default handler', req.method)
+    // should skip over this, because the 405 error took over.
+    throw new Error('should not be called ever')
+  })
+
+app.httpServer.listen(common.PORT, function () {
+  common.all(
+    [
+      [ function (cb) {
+          request.get({ url: URL }, cb)
+        }
+      , function (err, res, body) {
+          common.assertStatus(res, 200)
+          assert(getCalled)
+        }
+      ]
+    , [ function (cb) {
+          request.put({ url: URL, body:'ok' }, cb)
+        }
+      , function (err, res, body) {
+          common.assertStatus(res, 200)
+          assert(putCalled)
+        }
+      ]
+    , [ function (cb) {
+          request.del(URL, cb)
+        }
+      , function (err, res, body) {
+          // unsupported method
+          common.assertStatus(res, 405)
+        }
+      ]
+    , [ function (cb) {
+          request.post({ url: URL, body:'ok' }, cb);
+        }
+      ,
+        function (err, res, body) {
+          common.assertStatus(res, 200)
+          assert(postCalled)
+        }
+      ]
+    ]
+  , function () {app.close()})
+})
+


### PR DESCRIPTION
This is a bunch of the Route/plugins refactoring that we were talking about.  It's not ready for prime-time, but I want to check-in at this point to make sure we're not diverging.

Caveats:
1. `route.must('thing', handler)` breaks the pattern of `route.accepts(..., handler)`.  It makes it look like the handler you pass to must is what gets set if you DO have the thing, when in fact, it's what gets set if you _don't_ have it.  So you'd do something like `route.must('auth', 401)` to say "You must auth, or else you get a 401 error".
2. Something apparently is busted in filed when I try to use it for stuff, though all the tests pass.  I'm seeing a lot of `'Not Implemented, lazy (future) dynamic read/write discovery,'` errors.  Also, it seems to set the 200 status code, even when a file is being used as a 404 error, which is weird and wrong.
3. Error handling, omg, it's such a mess.  There needs to be some consistent/intuitive way to say, "Yeah, I know what I told you before, but forget all that, this is an error now, deal with it", and then provide some handler to send the error contents.  But, you probably want those error handlers to also do content type negotiation, so that means they really ought to be Routes rather than just handlers.
4. routes.Route vs Route vs route.Router vs Router.  This is extremely confusing and weird.  I cleaned it up a bit by making the result of router.match() go into req.match rather than req.route, so req.route is always and only a reference to the tako route.  But it's still really just kind of screwy still.  I get why there needs to be two kinds of Route objects (since routes.Route objects are just a dumb little regexp-and-function thingie), but why is there two different kinds of Routers?
