### PR TITLE
No more crashing on json parsing.

### DIFF
--- a/index.js
+++ b/index.js
@@ -567,7 +567,7 @@ function JSONRequestHandler (req, resp) {
     return orig.call(resp, chunk)
   }
   if (req.method === "PUT" || req.method === "POST") {
-    if (req.headers['content-type'] === 'application/json') {
+    if (req.headers['content-type'].split(';')[0] === 'application/json') {
       req.on('body', function (body) {
         try {
           req.emit('json', JSON.parse(body));
@@ -641,7 +641,7 @@ function Route (path, application) {
       if (req.method !== 'PUT' && req.method !== 'POST') {
         var cc = req.accept.apply(req, keys)
       } else {
-        var cc = req.headers['content-type']
+        var cc = req.headers['content-type'].split(';')[0];
       }
 
       if (!cc) return returnEarly(req, resp, keys, authHandler)

--- a/index.js
+++ b/index.js
@@ -569,7 +569,11 @@ function JSONRequestHandler (req, resp) {
   if (req.method === "PUT" || req.method === "POST") {
     if (req.headers['content-type'] === 'application/json') {
       req.on('body', function (body) {
-        req.emit('json', JSON.parse(body))
+        try {
+          req.emit('json', JSON.parse(body));
+        } catch (e) {
+          req.emit('error', e);
+        }
       })
     }
   }


### PR DESCRIPTION
Added try/catch to JSON.parse.
On error emits 'error' event, which can be handled much nicer than JSON.parse throw.

Lyrics: Some people used to send query string in the body of POST request
and if it crashes the server doesn't look too good.
