### PR TITLE
fixing proxypass pipe example in readme

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -32,7 +32,7 @@ var tako = require('tako')
 app.route('/static/*').files(path.join(__dirname, 'static'))
 
 app.route('/proxypass', function (req, resp) {
-  req.pipe(request("http://otherserver.com"+req.url)).pipe(resp)
+  req.pipe(request("http://otherserver.com"+req.url).pipe(resp))
 })
 
 app.route('/hello.json').json({msg:'hello!'})


### PR DESCRIPTION
one liner. The proxied request does not pipe to the response in the readme. Thought it could use an update as the example does not work.
