### PR TITLE
Export handlebars

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,6 +60,7 @@ var cap = function (stream, limit) {
 module.exports = function (options) {
   return new Application(options)
 }
+module.exports.handlebars = handlebars
 
 function BufferResponse (buffer, mimetype) {
   if (!Buffer.isBuffer(buffer)) this.body = new Buffer(buffer)


### PR DESCRIPTION
Hey Mikeal, I've been needing access to the handlebars export itself with a project I'm working on and thought this would be useful. The use case for me has been registering partial templates with handlebars.

For example, instead of:
`var handlebars = require('./node_modules/tako/handlebars.js')`
It would be:
`var handlebars = tako.handlebars`
